### PR TITLE
Prerelease v1.2.34-alpha.0

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -234,7 +234,7 @@ jobs:
           bucket-release: ${{ inputs.bucket-release-ci }}
 
       - name: Upload Release Note
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Release-Note-${{github.repository.name}}-${{github.sha}}
           path: |

--- a/.github/workflows/.release-verify.yml
+++ b/.github/workflows/.release-verify.yml
@@ -290,7 +290,7 @@ jobs:
           command: yarn run build
 
       - name: Upload Build Info
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.enabled && failure() }}
         with:
           name: "Build-Info-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
@@ -327,7 +327,7 @@ jobs:
         run: yarn run package
 
       - name: Upload Package Log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.enabled && failure() }}
         with:
           name: "Package-Log-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
@@ -337,7 +337,7 @@ jobs:
 
       - name: Upload Prebuilt (with versions)
         if: ${{ matrix.enabled && inputs.publish-versioning }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Prebuilt-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
           path: |
@@ -349,7 +349,7 @@ jobs:
 
       - name: Upload Prebuilt (without versions)
         if: ${{ matrix.enabled && !inputs.publish-versioning }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Prebuilt-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
           path: |
@@ -372,7 +372,7 @@ jobs:
 
       - name: Download Artifacts
         if: ${{ inputs.prebuild }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: "github-artifacts"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-trader/github-workflows",
-  "version": "1.2.33-alpha.6",
+  "version": "1.2.34-alpha.0",
   "repository": "https://github.com/kungfu-trader/workflows",
   "author": "Keren Dong",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-trader/github-workflows",
-  "version": "1.2.33-alpha.5",
+  "version": "1.2.33-alpha.6",
   "repository": "https://github.com/kungfu-trader/workflows",
   "author": "Keren Dong",
   "license": "Apache-2.0",


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact)


https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/