### PR TITLE
ci: gate self-hosted release builds

### DIFF
--- a/.github/workflows/.release-verify.yml
+++ b/.github/workflows/.release-verify.yml
@@ -37,12 +37,24 @@ on:
         default: ubuntu-22.04
         type: string
         required: false
+      build-runner-linux-labels:
+        default: ""
+        type: string
+        required: false
       build-runner-macos:
         default: macos-13
         type: string
         required: false
+      build-runner-macos-labels:
+        default: ""
+        type: string
+        required: false
       build-runner-windows:
         default: windows-2022
+        type: string
+        required: false
+      build-runner-windows-labels:
+        default: ""
         type: string
         required: false
       enable-linux:
@@ -192,24 +204,36 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    if: ${{ inputs.prebuild }}
+    if: >-
+      ${{
+        inputs.prebuild &&
+        (
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
     needs: prepare
+    permissions:
+      contents: read
+    concurrency:
+      group: heavy-build-${{ github.repository }}-${{ github.workflow }}-${{ matrix.name }}
+      cancel-in-progress: false
     strategy:
       matrix:
         include:
           - name: "Linux"
-            os: ${{ inputs.build-runner-linux }}
+            runner: ${{ inputs.build-runner-linux-labels || format('"{0}"', inputs.build-runner-linux) }}
             container: ${{ inputs.builder-container }}
             enabled: ${{ inputs.enable-linux }}
           - name: "MacOS"
-            os: ${{ inputs.build-runner-macos }}
+            runner: ${{ inputs.build-runner-macos-labels || format('"{0}"', inputs.build-runner-macos) }}
             enabled: ${{ inputs.enable-macos }}
             code-signing: ${{ inputs.code-signing-macos }}
           - name: "Windows"
-            os: ${{ inputs.build-runner-windows }}
+            runner: ${{ inputs.build-runner-windows-labels || format('"{0}"', inputs.build-runner-windows) }}
             enabled: ${{ inputs.enable-windows }}
             code-signing: ${{ inputs.code-signing-windows }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ fromJSON(matrix.runner) }}
     container: ${{ matrix.container }}
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -218,6 +242,9 @@ jobs:
       - name: Checkout
         if: ${{ matrix.enabled }}
         uses: actions/checkout@v3
+        with:
+          clean: true
+          persist-credentials: false
 
       - name: Configure Git safe directory
         if: ${{ matrix.enabled }}
@@ -360,6 +387,17 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-22.04
     steps:
+      - name: Reject untrusted prebuild PR
+        if: >-
+          ${{
+            inputs.prebuild &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name != github.repository
+          }}
+        run: |
+          echo "::error::Self-hosted prebuild is only allowed for trusted same-repository pull requests."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -424,7 +462,7 @@ jobs:
           find-dependencies: ${{ inputs.find-dependencies }}
 
       - name: Approve Merge
-        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ (!inputs.prebuild || needs.build.result == 'success') && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
         uses: kungfu-trader/action-approve@v1
         with:
           token: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- add optional self-hosted label arrays for release verify builds
- block fork PRs from running self-hosted prebuild jobs
- narrow build job permissions, clean checkout credentials, and serialize heavy build jobs

## Validation
- YAML parse passed locally
- structured workflow/caller audit passed locally
- runner labels match live kungfu-systems runners

Agent: Codex