### PR TITLE
ci: allow release verify PR updates

### DIFF
--- a/.github/workflows/.release-verify.yml
+++ b/.github/workflows/.release-verify.yml
@@ -178,6 +178,9 @@ jobs:
   prepare:
     runs-on: ubuntu-22.04
     container: ${{ inputs.builder-container }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -386,6 +389,9 @@ jobs:
     if: ${{ always() }}
     needs: [prepare, build]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Reject untrusted prebuild PR
         if: >-


### PR DESCRIPTION
## Summary
- grant release verify prepare/verify hosted jobs pull-requests: write
- keep contents read-only and leave build job contents-only

## Validation
- YAML parse passed locally
- structured permissions audit passed locally
- git diff --check passed

This is needed because action-bump-version updates PR title/comment during release verification.