### PR TITLE
ci: declare release verify caller permissions

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -11,6 +11,10 @@ on:
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   try:
     uses: ./.github/workflows/.release-verify.yml


### PR DESCRIPTION
## Summary
- grant release-verify caller workflow pull-requests: write
- keep contents read-only

## Validation
- YAML parse passed locally
- caller permissions audit passed locally
- git diff --check passed

This allows the reusable release verification workflow to update PR title/comment with GITHUB_TOKEN.