### PR TITLE
ci: parameterize bump action and runner selection

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -81,9 +81,17 @@ on:
         default: "32"
         type: string
         required: false
+      action-bump-version-repository:
+        default: "kungfu-systems/action-bump-version"
+        type: string
+        required: false
+      action-bump-version-ref:
+        default: "v3"
+        type: string
+        required: false
     secrets:
       GITHUB_PUSH_TOKEN:
-        required: true
+        required: false
       NPM_PUSH_TOKEN:
         required: false
       AWS_CI_ACCESS_KEY_ID:
@@ -109,16 +117,18 @@ jobs:
       issues: write
       pull-requests: write
     env:
-      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_PUSH_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check GitHub push token
-        if: ${{ inputs.publish-github-npm && secrets.GITHUB_PUSH_TOKEN == '' }}
-        run: |
-          echo "::error::GITHUB_PUSH_TOKEN is required for release publishing because action-bump-version@v3 updates repository settings."
-          exit 1
+      - name: Checkout Bump Version Action
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.action-bump-version-repository }}
+          ref: ${{ inputs.action-bump-version-ref }}
+          path: node_modules/.github-actions/action-bump-version
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
@@ -135,7 +145,9 @@ jobs:
           scope: "@${{github.repository_owner}}"
 
       - name: Bump Version
-        uses: kungfu-trader/action-bump-version@v3
+        uses: ./node_modules/.github-actions/action-bump-version
+        env:
+          KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
         with:
           token: ${{ github.token }}
           action: "prebuild"
@@ -182,11 +194,15 @@ jobs:
 
       - name: Publish New Version To GitHub
         if: ${{ github.event.pull_request.merged && inputs.publish-github-npm }}
-        uses: kungfu-trader/action-bump-version@v3
+        uses: ./node_modules/.github-actions/action-bump-version
+        env:
+          KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
         with:
-          token: ${{ secrets.GITHUB_PUSH_TOKEN }}
+          token: ${{ github.token }}
           action: "postbuild"
+          no-protection: "true"
           protect-dev-branches: ${{ inputs.protect-dev-branches }}
+          reset-default-branch: "false"
 
       - name: Setup NPM registry
         if: ${{ inputs.publish-npmjs }}
@@ -210,10 +226,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUSH_TOKEN }}
 
       - name: Rollback Check
-        if: ${{ failure() && secrets.GITHUB_PUSH_TOKEN != '' }}
+        if: ${{ failure() }}
         uses: kungfu-trader/action-rollback-release@v1
         with:
-          token: ${{ secrets.GITHUB_PUSH_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Close Issues
         if: github.event.pull_request.merged == true
@@ -256,11 +272,11 @@ jobs:
       - name: Sync Extensions Version Info To Airtable
         uses: kungfu-trader/action-sync-extensions-version@v1.0-alpha
         with:
-          token: ${{ secrets.GITHUB_PUSH_TOKEN }}
+          token: ${{ github.token }}
           apiKey: ${{ secrets.AIRTABLE_API_KEY }}
 
       - name: Trigger Qa Automated
         if: ${{ inputs.need-qa-automated }}
         uses: kungfu-trader/action-qa-automated@v1.0-alpha
         with:
-          token: ${{ secrets.GITHUB_PUSH_TOKEN }}
+          token: ${{ github.token }}

--- a/.github/workflows/.release-verify.yml
+++ b/.github/workflows/.release-verify.yml
@@ -145,6 +145,14 @@ on:
         default: "kungfu-developers"
         type: string
         required: false
+      action-bump-version-repository:
+        default: "kungfu-systems/action-bump-version"
+        type: string
+        required: false
+      action-bump-version-ref:
+        default: "v3"
+        type: string
+        required: false
     secrets:
       AWS_CI_ACCESS_KEY_ID:
         required: false
@@ -188,23 +196,35 @@ jobs:
       - name: Configure Git safe directory
         run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
 
-      - name: Set Pull Request Title
-        uses: kungfu-trader/action-bump-version@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          action: "verify"
-
-      - name: Set Collaborators
-        uses: kungfu-trader/action-set-collaborators@v1
-        with:
-          token: ${{ secrets.NODE_AUTH_TOKEN }}
-          manager: ${{ inputs.manager }}
-
       - name: Check Format
         if: ${{ inputs.check-format }}
         uses: kungfu-trader/action-check-format@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
+
+      - name: Checkout Bump Version Action
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.action-bump-version-repository }}
+          ref: ${{ inputs.action-bump-version-ref }}
+          path: node_modules/.github-actions/action-bump-version
+          persist-credentials: false
+
+      - name: Set Pull Request Title
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: ./node_modules/.github-actions/action-bump-version
+        env:
+          KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
+        with:
+          token: ${{ github.token }}
+          action: "verify"
+
+      - name: Set Collaborators
+        if: ${{ github.event_name == 'pull_request' && secrets.NODE_AUTH_TOKEN != '' }}
+        uses: kungfu-trader/action-set-collaborators@v1
+        with:
+          token: ${{ secrets.NODE_AUTH_TOKEN }}
+          manager: ${{ inputs.manager }}
 
   build:
     if: >-
@@ -239,7 +259,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.runner) }}
     container: ${{ matrix.container }}
     env:
-      NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || secrets.GITHUB_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
       USE_HARD_LINKS: false
     steps:
       - name: Checkout
@@ -247,6 +267,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           clean: true
+          persist-credentials: false
+
+      - name: Checkout Bump Version Action
+        if: ${{ matrix.enabled }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.action-bump-version-repository }}
+          ref: ${{ inputs.action-bump-version-ref }}
+          path: node_modules/.github-actions/action-bump-version
           persist-credentials: false
 
       - name: Configure Git safe directory
@@ -297,9 +326,11 @@ jobs:
 
       - name: Bump Version
         if: ${{ matrix.enabled }}
-        uses: kungfu-trader/action-bump-version@v3
+        uses: ./node_modules/.github-actions/action-bump-version
+        env:
+          KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           action: "prebuild"
 
       - name: Setup Build Environment
@@ -407,11 +438,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Checkout Bump Version Action
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.action-bump-version-repository }}
+          ref: ${{ inputs.action-bump-version-ref }}
+          path: node_modules/.github-actions/action-bump-version
+          persist-credentials: false
+
       - name: Bump Version
         if: ${{ inputs.prebuild }}
-        uses: kungfu-trader/action-bump-version@v3
+        uses: ./node_modules/.github-actions/action-bump-version
+        env:
+          KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           action: "prebuild"
 
       - name: Download Artifacts
@@ -432,7 +473,7 @@ jobs:
         if: ${{ inputs.prebuild && inputs.publish-aws-ci }}
         uses: kungfu-trader/action-publish-prebuilt@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           artifacts-path: "github-artifacts"
           bucket-staging: ${{ inputs.bucket-staging-ci }}
           no-comment: "true"
@@ -449,16 +490,19 @@ jobs:
         if: ${{ inputs.prebuild && inputs.publish-aws-user }}
         uses: kungfu-trader/action-publish-prebuilt@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           artifacts-path: "github-artifacts"
           bucket-staging: ${{ inputs.bucket-staging-user }}
           preview-files: ${{ inputs.preview-files }}
           max-preview-links: ${{ inputs.max-preview-links }}
 
       - name: Verify Version
-        uses: kungfu-trader/action-bump-version@v3
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: ./node_modules/.github-actions/action-bump-version
+        env:
+          KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           action: "verify"
 
       - name: Find Dependencies
@@ -468,7 +512,7 @@ jobs:
           find-dependencies: ${{ inputs.find-dependencies }}
 
       - name: Approve Merge
-        if: ${{ (!inputs.prebuild || needs.build.result == 'success') && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+        if: ${{ github.event_name == 'pull_request' && secrets.NODE_AUTH_TOKEN != '' && (!inputs.prebuild || needs.build.result == 'success') && !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
         uses: kungfu-trader/action-approve@v1
         with:
           token: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -19,5 +19,3 @@ jobs:
     with:
       publish-aws-ci: false
       publish-aws-user: false
-    secrets:
-      GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -24,7 +24,6 @@ jobs:
       find-dependencies: true
     secrets:
       AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
-      NODE_AUTH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
   
   verify:
     # report status for branch protection rule


### PR DESCRIPTION
## Summary
- add action-bump-version repository/ref inputs to release reusable workflows
- load action-bump-version through a local checkout path so callers can pin a test branch
- default release/verify token usage to github.token and keep high-privilege token paths optional

## Verification
- ruby YAML parse for changed workflow files
- git diff --check

## Notes
This branch is used by kungfu-systems/action-bump-version#pending to run a lightweight self-hosted runner smoke through release verify.