### PR TITLE
ci: run checked-out bump action directly

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -145,12 +145,11 @@ jobs:
           scope: "@${{github.repository_owner}}"
 
       - name: Bump Version
-        uses: ./node_modules/.github-actions/action-bump-version
+        run: node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
-        with:
-          token: ${{ github.token }}
-          action: "prebuild"
+          INPUT_TOKEN: ${{ github.token }}
+          INPUT_ACTION: "prebuild"
 
       - name: Configure AWS Crendentials (CI)
         if: ${{ inputs.publish-aws-ci }}
@@ -194,15 +193,14 @@ jobs:
 
       - name: Publish New Version To GitHub
         if: ${{ github.event.pull_request.merged && inputs.publish-github-npm }}
-        uses: ./node_modules/.github-actions/action-bump-version
+        run: node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
-        with:
-          token: ${{ github.token }}
-          action: "postbuild"
-          no-protection: "true"
-          protect-dev-branches: ${{ inputs.protect-dev-branches }}
-          reset-default-branch: "false"
+          INPUT_TOKEN: ${{ github.token }}
+          INPUT_ACTION: "postbuild"
+          INPUT_NO-PROTECTION: "true"
+          INPUT_PROTECT-DEV-BRANCHES: ${{ inputs.protect-dev-branches }}
+          INPUT_RESET-DEFAULT-BRANCH: "false"
 
       - name: Setup NPM registry
         if: ${{ inputs.publish-npmjs }}

--- a/.github/workflows/.release-verify.yml
+++ b/.github/workflows/.release-verify.yml
@@ -212,12 +212,11 @@ jobs:
 
       - name: Set Pull Request Title
         if: ${{ github.event_name == 'pull_request' }}
-        uses: ./node_modules/.github-actions/action-bump-version
+        run: node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
-        with:
-          token: ${{ github.token }}
-          action: "verify"
+          INPUT_TOKEN: ${{ github.token }}
+          INPUT_ACTION: "verify"
 
       - name: Set Collaborators
         if: ${{ github.event_name == 'pull_request' && secrets.NODE_AUTH_TOKEN != '' }}
@@ -326,12 +325,11 @@ jobs:
 
       - name: Bump Version
         if: ${{ matrix.enabled }}
-        uses: ./node_modules/.github-actions/action-bump-version
+        run: node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
-        with:
-          token: ${{ github.token }}
-          action: "prebuild"
+          INPUT_TOKEN: ${{ github.token }}
+          INPUT_ACTION: "prebuild"
 
       - name: Setup Build Environment
         if: ${{ matrix.enabled }}
@@ -448,12 +446,11 @@ jobs:
 
       - name: Bump Version
         if: ${{ inputs.prebuild }}
-        uses: ./node_modules/.github-actions/action-bump-version
+        run: node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
-        with:
-          token: ${{ github.token }}
-          action: "prebuild"
+          INPUT_TOKEN: ${{ github.token }}
+          INPUT_ACTION: "prebuild"
 
       - name: Download Artifacts
         if: ${{ inputs.prebuild }}
@@ -498,12 +495,11 @@ jobs:
 
       - name: Verify Version
         if: ${{ github.event_name == 'pull_request' }}
-        uses: ./node_modules/.github-actions/action-bump-version
+        run: node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
-        with:
-          token: ${{ github.token }}
-          action: "verify"
+          INPUT_TOKEN: ${{ github.token }}
+          INPUT_ACTION: "verify"
 
       - name: Find Dependencies
         uses: kungfu-trader/action-find-dependencies@v1


### PR DESCRIPTION
## Summary
- replace local action uses with direct node execution of the checked-out action bundle
- keep action-bump-version repository/ref parameterization without relying on dynamic uses or local action path resolution

## Verification
- ruby YAML parse for changed workflow files
- git diff --check

## Context
Follow-up for action-bump-version release startup failure 28291557209.