### PR TITLE
ci: pass hyphenated bump inputs via env command

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -193,14 +193,16 @@ jobs:
 
       - name: Publish New Version To GitHub
         if: ${{ github.event.pull_request.merged && inputs.publish-github-npm }}
-        run: node node_modules/.github-actions/action-bump-version/dist/index.js
+        run: >-
+          env
+          'INPUT_NO-PROTECTION=true'
+          'INPUT_PROTECT-DEV-BRANCHES=${{ inputs.protect-dev-branches }}'
+          'INPUT_RESET-DEFAULT-BRANCH=false'
+          node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"
           INPUT_TOKEN: ${{ github.token }}
           INPUT_ACTION: "postbuild"
-          INPUT_NO-PROTECTION: "true"
-          INPUT_PROTECT-DEV-BRANCHES: ${{ inputs.protect-dev-branches }}
-          INPUT_RESET-DEFAULT-BRANCH: "false"
 
       - name: Setup NPM registry
         if: ${{ inputs.publish-npmjs }}


### PR DESCRIPTION
## Summary
- move hyphenated action input env vars out of workflow env map
- pass them through shell env invocation for the checked-out action bundle

## Verification
- ruby YAML parse for changed workflow files
- git diff --check

## Context
Follow-up for release startup_failure after PR #248.