### PR TITLE
ci: modernize release workflow runners

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       node-version:
-        default: "16"
+        default: "24"
         type: string
         required: false
       protect-dev-branches:
@@ -110,7 +110,7 @@ on:
 jobs:
   release:
     if: ${{ github.event.pull_request.merged }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       packages: write
@@ -120,10 +120,10 @@ jobs:
       NODE_AUTH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
 
       - name: Checkout Bump Version Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
         with:
           repository: ${{ inputs.action-bump-version-repository }}
           ref: ${{ inputs.action-bump-version-ref }}
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: "https://npm.pkg.github.com"
@@ -139,7 +139,7 @@ jobs:
 
       - name: Setup Node.js registry scope
         if: ${{ inputs.publish-github-npm }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6.4.0
         with:
           registry-url: "https://npm.pkg.github.com"
           scope: "@${{github.repository_owner}}"
@@ -153,7 +153,7 @@ jobs:
 
       - name: Configure AWS Crendentials (CI)
         if: ${{ inputs.publish-aws-ci }}
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_CI_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CI_SECRET_ACCESS_KEY }}
@@ -173,7 +173,7 @@ jobs:
 
       - name: Configure AWS Crendentials (User)
         if: ${{ inputs.publish-aws-user }}
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_USER_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_USER_SECRET_ACCESS_KEY }}
@@ -206,14 +206,14 @@ jobs:
 
       - name: Setup NPM registry
         if: ${{ inputs.publish-npmjs }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup NPM registry for owner
         if: ${{ inputs.publish-npmjs }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: "https://registry.npmjs.org"
@@ -247,7 +247,7 @@ jobs:
 
       - name: Convert Release Note To Pdf
         if: steps.create_release_note.outputs.has_notes == 'true'
-        uses: baileyjm02/markdown-to-pdf@v1
+        uses: baileyjm02/markdown-to-pdf@v1.2.0
         with:
           input_dir: notes
           output_dir: pdfs
@@ -261,7 +261,7 @@ jobs:
           bucket-release: ${{ inputs.bucket-release-ci }}
 
       - name: Upload Release Note
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: Release-Note-${{github.repository.name}}-${{github.sha}}
           path: |

--- a/.github/workflows/.release-verify.yml
+++ b/.github/workflows/.release-verify.yml
@@ -6,7 +6,7 @@ on:
         type: boolean
         required: false
       node-version:
-        default: "16"
+        default: "24"
         type: string
         required: false
       python-version:
@@ -34,7 +34,7 @@ on:
         type: string
         required: false
       build-runner-linux:
-        default: ubuntu-22.04
+        default: ubuntu-24.04
         type: string
         required: false
       build-runner-linux-labels:
@@ -184,14 +184,19 @@ env:
 
 jobs:
   prepare:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ inputs.builder-container }}
     permissions:
       contents: read
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
@@ -203,7 +208,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Checkout Bump Version Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
         with:
           repository: ${{ inputs.action-bump-version-repository }}
           ref: ${{ inputs.action-bump-version-ref }}
@@ -247,14 +252,17 @@ jobs:
             runner: ${{ inputs.build-runner-linux-labels || format('"{0}"', inputs.build-runner-linux) }}
             container: ${{ inputs.builder-container }}
             enabled: ${{ inputs.enable-linux }}
+            local-node: ${{ inputs.build-runner-linux-labels != '' && inputs.builder-container == '' }}
           - name: "MacOS"
             runner: ${{ inputs.build-runner-macos-labels || format('"{0}"', inputs.build-runner-macos) }}
             enabled: ${{ inputs.enable-macos }}
             code-signing: ${{ inputs.code-signing-macos }}
+            local-node: false
           - name: "Windows"
             runner: ${{ inputs.build-runner-windows-labels || format('"{0}"', inputs.build-runner-windows) }}
             enabled: ${{ inputs.enable-windows }}
             code-signing: ${{ inputs.code-signing-windows }}
+            local-node: false
     runs-on: ${{ fromJSON(matrix.runner) }}
     container: ${{ matrix.container }}
     env:
@@ -263,14 +271,14 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ matrix.enabled }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
         with:
           clean: true
           persist-credentials: false
 
       - name: Checkout Bump Version Action
         if: ${{ matrix.enabled }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
         with:
           repository: ${{ inputs.action-bump-version-repository }}
           ref: ${{ inputs.action-bump-version-ref }}
@@ -281,6 +289,16 @@ jobs:
         if: ${{ matrix.enabled }}
         run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
 
+      - name: Show Local Node
+        if: ${{ matrix.enabled && matrix.local-node }}
+        run: |
+          echo "runner.name=${RUNNER_NAME}"
+          echo "runner.os=${RUNNER_OS}"
+          echo "runner.arch=${RUNNER_ARCH}"
+          node --version
+          npm --version
+          yarn --version
+
       # - name: Setup Java environment
       #   if: ${{ matrix.enabled && !matrix.container }}
       #   uses: actions/setup-java@v3
@@ -289,23 +307,23 @@ jobs:
       #     distribution: "temurin"
 
       - name: Setup Node.js environment
-        if: ${{ matrix.enabled }}
-        uses: actions/setup-node@v3
+        if: ${{ matrix.enabled && !matrix.local-node }}
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: "https://npm.pkg.github.com"
           scope: "@kungfu-trader"
 
       - name: Setup Node.js registry scope
-        if: ${{ matrix.enabled && inputs.publish-github-npm }}
-        uses: actions/setup-node@v3
+        if: ${{ matrix.enabled && !matrix.local-node && inputs.publish-github-npm }}
+        uses: actions/setup-node@v6.4.0
         with:
           registry-url: "https://npm.pkg.github.com"
           scope: "@${{github.repository_owner}}"
 
       - name: Setup Python environment
         if: ${{ matrix.enabled && !matrix.container }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ inputs.python-version }}
 
@@ -349,7 +367,7 @@ jobs:
           command: yarn run build
 
       - name: Upload Build Info
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: ${{ matrix.enabled && failure() }}
         with:
           name: "Build-Info-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
@@ -386,7 +404,7 @@ jobs:
         run: yarn run package
 
       - name: Upload Package Log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         if: ${{ matrix.enabled && failure() }}
         with:
           name: "Package-Log-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
@@ -396,7 +414,7 @@ jobs:
 
       - name: Upload Prebuilt (with versions)
         if: ${{ matrix.enabled && inputs.publish-versioning }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: "Prebuilt-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
           path: |
@@ -408,7 +426,7 @@ jobs:
 
       - name: Upload Prebuilt (without versions)
         if: ${{ matrix.enabled && !inputs.publish-versioning }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: "Prebuilt-${{github.sha}}-${{matrix.name}}-${{github.actor}}-${{github.sha}}"
           path: |
@@ -417,7 +435,7 @@ jobs:
   verify:
     if: ${{ always() }}
     needs: [prepare, build]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
@@ -434,10 +452,15 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
 
       - name: Checkout Bump Version Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7.0.0
         with:
           repository: ${{ inputs.action-bump-version-repository }}
           ref: ${{ inputs.action-bump-version-ref }}
@@ -454,13 +477,13 @@ jobs:
 
       - name: Download Artifacts
         if: ${{ inputs.prebuild }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: "github-artifacts"
 
       - name: Configure AWS Crendentials (CI)
         if: ${{ inputs.prebuild && inputs.publish-aws-ci }}
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_CI_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CI_SECRET_ACCESS_KEY }}
@@ -477,7 +500,7 @@ jobs:
 
       - name: Configure AWS Crendentials (User)
         if: ${{ inputs.prebuild && inputs.publish-aws-user }}
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_USER_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_USER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -28,7 +28,7 @@ jobs:
   verify:
     # report status for branch protection rule
     needs: try
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: report
         run: echo verified


### PR DESCRIPTION
## Summary
- default release reusable workflows to Node 24 and Ubuntu 24.04
- upgrade GitHub-maintained release actions to current pinned tags
- keep the full release-verify build matrix while allowing Linux self-hosted jobs without setup-node only when no build container is used

## Verification
- ruby YAML parser for changed workflows
- git diff --check
- GitHub API tag existence checks for upgraded actions

## Notes
- This branch intentionally does not merge the earlier minimal diagnostic workflow; it ports only the production-safe changes onto the full default-branch matrix.