### PR TITLE
fix: skip protected release branch push in postbuild

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -214,6 +214,7 @@ jobs:
           'INPUT_NO-PROTECTION=true'
           'INPUT_PROTECT-DEV-BRANCHES=${{ inputs.protect-dev-branches }}'
           'INPUT_RESET-DEFAULT-BRANCH=false'
+          'INPUT_SKIP-BASE-BRANCH-PUSH=true'
           node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"


### PR DESCRIPTION
## Summary

Pass `INPUT_SKIP-BASE-BRANCH-PUSH=true` to action-bump-version postbuild from the shared release workflow.

Release branches are already updated by the merged release PR and are protected against direct force-pushes. Postbuild should still publish tags and advance alpha tags, but must not directly push `release/*/*`.

## Validation

- `actionlint .github/workflows/*.yml`
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn build`
- `yarn package`
- `git diff --check`
