### PR TITLE
Prerelease v2.0.0-alpha.1

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -214,6 +214,7 @@ jobs:
           'INPUT_NO-PROTECTION=true'
           'INPUT_PROTECT-DEV-BRANCHES=${{ inputs.protect-dev-branches }}'
           'INPUT_RESET-DEFAULT-BRANCH=false'
+          'INPUT_SKIP-BASE-BRANCH-PUSH=true'
           node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-systems/github-workflows",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "repository": "https://github.com/kungfu-systems/workflows",
   "author": "Keren Dong",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Prerelease the workflows v2 postbuild fix that skips direct pushes to protected release branches.

## Validation

- Fix PR #258 local checks passed before merge
- This PR runs the standard lightweight release-verify path
