### PR TITLE
Release v2.0.0

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -214,6 +214,7 @@ jobs:
           'INPUT_NO-PROTECTION=true'
           'INPUT_PROTECT-DEV-BRANCHES=${{ inputs.protect-dev-branches }}'
           'INPUT_RESET-DEFAULT-BRANCH=false'
+          'INPUT_SKIP-BASE-BRANCH-PUSH=true'
           node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-systems/github-workflows",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "repository": "https://github.com/kungfu-systems/workflows",
   "author": "Keren Dong",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Retry the v2.0.0 stable promotion with the protected release branch postbuild fix included.

The previous stable run created tags but failed when postbuild tried to force-push the protected release branch. This release branch now passes `INPUT_SKIP-BASE-BRANCH-PUSH=true`, so postbuild should publish tags without directly pushing `release/*/*`.

## Validation

- Alpha fix PR #259 passed release-verify and merged
- Alpha release run `28326838596` succeeded
