### PR TITLE
fix: skip protected channel merge in postbuild

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -215,6 +215,7 @@ jobs:
           'INPUT_PROTECT-DEV-BRANCHES=${{ inputs.protect-dev-branches }}'
           'INPUT_RESET-DEFAULT-BRANCH=false'
           'INPUT_SKIP-BASE-BRANCH-PUSH=true'
+          'INPUT_SKIP-CHANNEL-BRANCH-MERGE=true'
           node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"


### PR DESCRIPTION
## Summary

Pass `INPUT_SKIP-CHANNEL-BRANCH-MERGE=true` to action-bump-version postbuild from the shared release workflow.

Protected channel branches are advanced by PRs, not by direct API merges from release postbuild.

## Validation

- `actionlint .github/workflows/*.yml`
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn build`
- `yarn package`
- `git diff --check`
