### PR TITLE
Release v2.0.0

### DIFF
--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -215,6 +215,7 @@ jobs:
           'INPUT_PROTECT-DEV-BRANCHES=${{ inputs.protect-dev-branches }}'
           'INPUT_RESET-DEFAULT-BRANCH=false'
           'INPUT_SKIP-BASE-BRANCH-PUSH=true'
+          'INPUT_SKIP-CHANNEL-BRANCH-MERGE=true'
           node node_modules/.github-actions/action-bump-version/dist/index.js
         env:
           KUNGFU_ACTION_BUMP_VERSION_ALLOW_LOCAL: "true"

--- a/.github/workflows/.release-new-version.yml
+++ b/.github/workflows/.release-new-version.yml
@@ -255,39 +255,12 @@ jobs:
           token: ${{ github.token }}
           monday_api_key: ${{ secrets.MONDAY_API_KEY }}
 
-      - name: Create Release Note
+      - name: Reject retired Airtable release note
         if: ${{ inputs.create-release-note || inputs.publish-release-note }}
-        id: create_release_note
-        uses: kungfu-systems/action-release-note@v1.0-alpha
-        with:
-          token: ${{ github.token }}
-          apiKey: ${{ secrets.AIRTABLE_API_KEY }}
-
-      - name: Convert Release Note To Pdf
-        if: ${{ (inputs.create-release-note || inputs.publish-release-note) && steps.create_release_note.outputs.has_notes == 'true' }}
-        uses: baileyjm02/markdown-to-pdf@v1.2.0
-        with:
-          input_dir: notes
-          output_dir: pdfs
-          build_html: true
-
-      - name: Publish Release Note To AWS
-        if: ${{ inputs.publish-release-note }}
-        uses: kungfu-systems/action-release-note@v1.0-alpha
-        with:
-          token: ${{ github.token }}
-          apiKey: ${{ secrets.AIRTABLE_API_KEY }}
-          bucket-release: ${{ inputs.bucket-release-ci }}
-
-      - name: Upload Release Note
-        if: ${{ inputs.create-release-note || inputs.publish-release-note }}
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: Release-Note-${{ github.event.repository.name }}-${{ github.sha }}
-          path: |
-            notes/*
-            pdfs/*
-          if-no-files-found: ignore
+        run: |
+          echo "::error::Airtable-backed release note generation is retired in workflows v2."
+          echo "::error::Do not enable create-release-note or publish-release-note until the release note mechanism is redesigned."
+          exit 1
 
       - name: Reject retired extensions Airtable sync
         if: ${{ inputs.sync-extensions-version }}

--- a/.github/workflows/.sam-release.yml
+++ b/.github/workflows/.sam-release.yml
@@ -49,7 +49,6 @@ jobs:
           role-session-name: github-dev
           aws-region: ${{ inputs.aws-region }}
 
-      # Build inside Docker containers
-      - run: sam build --use-container
+      - run: sam build
       # Prevent prompts and failure when the stack is unchanged
       - run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/.sam-verify.yml
+++ b/.github/workflows/.sam-verify.yml
@@ -56,8 +56,7 @@ jobs:
           role-session-name: github-dev
           aws-region: ${{ inputs.aws-region }}
 
-      # Build inside Docker containers
-      - run: sam build --use-container
+      - run: sam build
 
   verify:
     if: ${{ always() }}

--- a/.github/workflows/.sync-release-page.yml
+++ b/.github/workflows/.sync-release-page.yml
@@ -55,53 +55,14 @@ on:
 
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   sync-release-page:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-
-      - name: Configure AWS Crendentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ inputs.aws-role-arn }}
-          role-session-name: github-dev
-          aws-region: ${{ inputs.aws-region }}
-
-      - name: Generate Download Page
-        if: ${{ github.event.pull_request.merged }}
-        uses: kungfu-systems/action-generate-download-page@dev/v1/v1.0
-        with:
-          apiKey: ${{ secrets.AIRTABLE_API_KEY }}
-          bucket-release: ${{ inputs.bucket-release }}
-          airtable-baseid: ${{ inputs.base-id }}
-
-      - name: Generate Release Page
-        uses: kungfu-systems/action-generate-release-page@dev/v1/v1.0
-        with:
-          token: ${{ secrets.GITHUB_PUSH_TOKEN }}
-          apiKey: ${{ secrets.AIRTABLE_API_KEY }}
-          product: ${{ inputs.product }}
-          repo: ${{ inputs.repo }}
-          product-name: ${{ inputs.product-name }}
-          release-path: ${{ inputs.release-path }}
-          release-url: ${{ inputs.release-url }}
-          lower-edge: ${{ inputs.lower-edge }}
-          upper-edge: ${{ inputs.upper-edge }}
-          exclude: ${{ inputs.exclude }}
-          base-id: ${{ inputs.base-id }}
-          bucket-release: ${{ inputs.bucket-release }}
-
-      - name: Publish Release Page to AWS
-        uses: kungfu-systems/action-publish-prebuilt@v2
-        with:
-          token: ${{ secrets.GITHUB_PUSH_TOKEN }}
-          artifacts-path: "dist"
-          bucket-release: ${{ inputs.bucket-release }}
-          clean-release: false
-          cloudfront-id: ${{ inputs.cloudfront-id }}
-          cloudfront-paths: /${{ inputs.release-path }}/*
+      - name: Reject retired Airtable release page sync
+        run: |
+          echo "::error::The Airtable-backed release page synchronization workflow is retired in workflows v2."
+          echo "::error::Do not route modern releases through AIRTABLE_API_KEY, base-id, or the legacy release page sync actions."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ The v2 line is the modernized baseline for Kungfu v4 workflow work:
 - reusable workflows call `kungfu-systems/action-bump-version` v4 by default.
 - Linux heavy builds are expected to use trusted self-hosted runner labels.
 - Docker/container build paths are retired until the Docker mechanism is redesigned.
-- legacy Monday/release-note integrations are opt-in.
+- legacy Monday integration remains opt-in.
+- Airtable-backed release note generation is retired and fails fast when
+  explicitly enabled.
 - legacy collaborator, dependency discovery, and Airtable extension sync helpers
   are retired and fail fast when explicitly enabled.
 - auto-approval remains opt-in and depends on the modernized
   `kungfu-systems/action-approve` action line.
-- Airtable workflow entrypoints are retired and removed.
+- Airtable workflow entrypoints are retired; remaining compatibility stubs fail
+  fast instead of invoking Airtable-backed actions.
 - non-Airtable legacy scheduled sync and purge jobs are retired by default and
   require manual `workflow_dispatch` confirmation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kungfu-systems/github-workflows",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "repository": "https://github.com/kungfu-systems/workflows",
   "author": "Keren Dong",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Retry the v2.0.0 stable promotion with the protected-branch release fixes included.

This alpha includes postbuild inputs to skip direct writes to protected release/channel branches.

## Validation

- Alpha release run `28327362002` succeeded
