### PR TITLE
Use stable bootstrap refs for v2 release workflows

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -19,4 +19,4 @@ jobs:
     with:
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -19,7 +19,7 @@ jobs:
       prebuild: false
       find-dependencies: false
       publish-versioning: false
-      action-bump-version-ref: dev/v4/v4.0
+      action-bump-version-ref: v4
   
   verify:
     # report status for branch protection rule


### PR DESCRIPTION
## Summary\n- use action-bump-version@v4 for v2 release and verify workflows\n- remove dev/v4 bootstrap refs from the stable v2 line\n\n## Verification\n- actionlint .github/workflows/release-new-version.yml .github/workflows/release-verify.yml\n- git diff --check