### PR TITLE
Allow PR reads in release verify build jobs

### DIFF
--- a/.github/workflows/.release-verify.yml
+++ b/.github/workflows/.release-verify.yml
@@ -253,6 +253,7 @@ jobs:
     needs: prepare
     permissions:
       contents: read
+      pull-requests: read
     concurrency:
       group: heavy-build-${{ github.repository }}-${{ github.workflow }}-${{ matrix.name }}
       cancel-in-progress: false
@@ -461,6 +462,7 @@ jobs:
     needs: prepare
     permissions:
       contents: read
+      pull-requests: read
     concurrency:
       group: heavy-build-${{ github.repository }}-${{ github.workflow }}-Linux-local
       cancel-in-progress: false


### PR DESCRIPTION
## Summary\n- grant pull-requests: read to build and build_local jobs in the reusable release verify workflow\n- allow action-bump-version prebuild to read PR metadata when build_local runs under job-level permissions\n\n## Verification\n- actionlint .github/workflows/.release-verify.yml\n- git diff --check